### PR TITLE
Add map to scrolling container

### DIFF
--- a/components/MyGroups/MyGroups.tsx
+++ b/components/MyGroups/MyGroups.tsx
@@ -200,15 +200,21 @@ export default class MyGroups extends JCComponent<Props, State> {
     })
   }
 
-  convertProfileToMapData(): any {
-    return [{
-      latitude: 30.01,
-      longitude: 40.02,
-      name: "Bob",
-      link: "",
-      type: "profile"
-    }]
+  convertProfileToMapData(data): [] {
+    return data.map((dataItem) => {
+      if (dataItem.location && dataItem.location.latitude && dataItem.location.longitude)
+        return {
+          latitude: dataItem.location.latitude,
+          longitude: dataItem.location.longitude,
+          name: dataItem.given_name + " " + dataItem.family_name,
+          user: dataItem,
+          link: "",
+          type: "profile"
+        }
+      else return null
+    }).filter(o => o)
   }
+
   convertEventToMapData(data): [] {
     return data.map((dataItem) => {
       if (dataItem.locationLatLong && dataItem.locationLatLong.latitude && dataItem.locationLatLong.longitude)
@@ -236,7 +242,7 @@ export default class MyGroups extends JCComponent<Props, State> {
       case "course":
         return []
       case "profile":
-        return this.convertProfileToMapData()
+        return this.convertProfileToMapData(data)
     }
 
   }

--- a/components/MyMap/MyMap.tsx
+++ b/components/MyMap/MyMap.tsx
@@ -9,15 +9,14 @@ interface Props {
   navigation?: any
   route?: any
   visible: boolean
-  mapData?: any
-  showFilters?: boolean
+  mapData: any
+  type: string
   initCenter?: any
+  size?: string
 }
 class MyMapImpl extends JCComponent<Props> {
   constructor(props: Props) {
     super(props);
-    if (props.showFilters == undefined)
-      props.showFilters = true
 
   }
   mapstyle = [

--- a/components/MyMap/MyMap.web.tsx
+++ b/components/MyMap/MyMap.web.tsx
@@ -7,8 +7,7 @@ import { Body, Card, CardItem, Button, View } from 'native-base';
 import { TouchableOpacity, Animated, TouchableWithoutFeedback } from 'react-native'
 
 
-
-import { Marker, Circle } from 'google-maps-react';
+import { Marker } from 'google-maps-react';
 import { Map, InfoWindow } from 'google-maps-react';
 import ProfileImage from '../../components/ProfileImage/ProfileImage'
 
@@ -25,9 +24,10 @@ interface Props {
   route?: any
   visible: boolean
   google: any
-  mapData?: any
-  showFilters?: boolean
+  mapData: any
+  type: string
   initCenter?: any
+  size?: string
 }
 interface State {
   selectedPlace: any
@@ -211,7 +211,7 @@ class MyMapImpl extends JCComponent<Props, State> {
   }
   render() {
     //console.log(this.props.mapData)
-    if (this.props.visible && this.props.showFilters)
+    if (this.props.visible && this.props.type === "filters") {
       return (
         <ErrorBoundary>
 
@@ -384,8 +384,9 @@ class MyMapImpl extends JCComponent<Props, State> {
 
         </ErrorBoundary>
       )
+    }
 
-    else if (this.props.visible && !this.props.showFilters) {
+    else if (this.props.visible && this.props.type === "profile") {
       return (
         <ErrorBoundary>
 
@@ -417,6 +418,60 @@ class MyMapImpl extends JCComponent<Props, State> {
       )
     }
 
+    else if (this.props.type === "no-filters") {
+      //the visible prop controls height because the map must render to set the correct center position 
+      return (
+        <ErrorBoundary>
+
+          <View style={{ height: this.props.visible ? this.props.size ? this.props.size : 510 : 0 }}>
+
+            <Map google={window.google} zoom={6}
+              center={this.props.initCenter ? this.props.initCenter : { lat: 44, lng: -78 }}
+              mapTypeControl={false}
+              onClick={this.onMapClicked}
+              onReady={(mapProps, map) => this._mapLoaded(map)}
+              style={{ position: "relative", width: "100%", height: "100%" }}
+              streetViewControl={false}
+              fullscreenControl={false}
+            >
+
+              {this.props.mapData.map((mapItem, index) => {
+
+                return <Marker key={index} title={mapItem.name}
+                  mapItemType={mapItem.type}
+                  mapItem={mapItem}
+                  onClick={this.onMarkerClick}
+                  position={{ lat: mapItem.latitude, lng: mapItem.longitude }}
+                  icon={{
+                    url: require("../../assets/svg/map-icon-red.svg"),
+                    scaledSize: new google.maps.Size(32, 32)
+                  }}>
+                </Marker>
+
+              })}
+
+
+              <InfoWindow
+                google={window.google}
+                visible={this.state.showingInfoWindow}
+                marker={this.state.activeMarker}>
+                {this.state.selectedPlace != null ?
+                  this.state.selectedPlace.mapItemType == "profile" ?
+                    this.renderProfile() :
+                    this.state.selectedPlace.mapItemType == "event" ?
+                      this.renderEvent()
+                      : null
+                  : null
+                }
+
+              </InfoWindow>
+
+            </Map>
+          </View>
+
+        </ErrorBoundary>
+      )
+    }
     else return null
   }
 }

--- a/components/MyMap/MyMap.web.tsx
+++ b/components/MyMap/MyMap.web.tsx
@@ -8,10 +8,6 @@ import { TouchableOpacity, Animated, TouchableWithoutFeedback } from 'react-nati
 
 
 import { Marker } from 'google-maps-react';
-<<<<<<< HEAD
-=======
-
->>>>>>> 5a3b6c3a1464ca2cbba7d5dbd2c10e9a942bc14b
 import { Map, InfoWindow } from 'google-maps-react';
 import ProfileImage from '../../components/ProfileImage/ProfileImage'
 
@@ -389,11 +385,6 @@ class MyMapImpl extends JCComponent<Props, State> {
         </ErrorBoundary>
       )
     }
-<<<<<<< HEAD
-
-=======
-    
->>>>>>> 5a3b6c3a1464ca2cbba7d5dbd2c10e9a942bc14b
     else if (this.props.visible && this.props.type === "profile") {
       return (
         <ErrorBoundary>
@@ -431,7 +422,6 @@ class MyMapImpl extends JCComponent<Props, State> {
       return (
         <ErrorBoundary>
 
-<<<<<<< HEAD
           <View style={{ height: this.props.visible ? this.props.size ? this.props.size : 510 : 0 }}>
 
             <Map google={window.google} zoom={6}
@@ -476,52 +466,6 @@ class MyMapImpl extends JCComponent<Props, State> {
               </InfoWindow>
 
             </Map>
-=======
-          <View style={{ height: this.props.visible ? this.props.size ? this.props.size : 510 : 0}}>
-
-              <Map google={window.google} zoom={6}
-                center={this.props.initCenter ? this.props.initCenter : {lat: 44, lng: -78}}
-                mapTypeControl={false}
-                onClick={this.onMapClicked}
-                onReady={(mapProps, map) => this._mapLoaded(map)}
-                style={{ position: "relative", width: "100%", height: "100%" }}
-                streetViewControl={false}
-                fullscreenControl={false}
-              >
-
-                {this.props.mapData.map((mapItem, index) => {
-
-                    return <Marker key={index} title={mapItem.name}
-                      mapItemType={mapItem.type}
-                      mapItem={mapItem}
-                      onClick={this.onMarkerClick}
-                      position={{ lat: mapItem.latitude, lng: mapItem.longitude }}
-                      icon={{
-                        url: require("../../assets/svg/map-icon-red.svg"),
-                        scaledSize: new google.maps.Size(32, 32)
-                      }}>
-                    </Marker>
-
-                  })}
-
-
-                <InfoWindow
-                  google={window.google}
-                  visible={this.state.showingInfoWindow}
-                  marker={this.state.activeMarker}>
-                  {this.state.selectedPlace != null ?
-                    this.state.selectedPlace.mapItemType == "profile" ?
-                      this.renderProfile() :
-                      this.state.selectedPlace.mapItemType == "event" ?
-                        this.renderEvent()
-                        : null
-                    : null
-                  }
-
-                </InfoWindow>
-
-              </Map>
->>>>>>> 5a3b6c3a1464ca2cbba7d5dbd2c10e9a942bc14b
           </View>
 
         </ErrorBoundary>

--- a/components/MyPeople/MyPeople.tsx
+++ b/components/MyPeople/MyPeople.tsx
@@ -68,7 +68,7 @@ export default class MyPeople extends JCComponent<Props, State> {
   setInitialData() {
     const listUsers: any = API.graphql({
       query: queries.listUsers,
-      variables: { filter: { profileState: { eq: "Complete" }, id: { ne: this.state.currentUser } } },
+      variables: { filter: { profileState: { eq: "Complete" } } },
       authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS
     });
 
@@ -109,24 +109,28 @@ export default class MyPeople extends JCComponent<Props, State> {
             <Button style={this.styles.style.connectWithTopSectionButton} onPress={() => { this.showProfiles() }} transparent><Text style={this.styles.style.fontConnectWith}>People you may connect with</Text></Button>
             <Content style={this.styles.style.rightCardWidth}>
               {this.state.data.map((item: any) => {
-                return (
-                  <TouchableOpacity key={item.id} onPress={() => { this.showProfile(item.id) }}>
-                    <Card style={this.styles.style.dashboardConversationCard}>
-                      <CardItem>
-                        <Left>
-                          <ProfileImage user={item} size='small'>
-                          </ProfileImage>
+                if (item.id !== this.state.currentUser) {
+                  return (
+                    <TouchableOpacity key={item.id} onPress={() => { this.showProfile(item.id) }}>
+                      <Card style={styles.dashboardConversationCard}>
+                        <CardItem>
+                          <Left>
+                            <ProfileImage user={item} size='small'>
+                            </ProfileImage>
 
-                          <Body>
-                            <Text style={this.styles.style.fontConnectWithName}>{item.given_name} {item.family_name}</Text>
-                            <Text style={this.styles.style.fontConnectWithRole}>{item.currentRole}</Text>
-                            <Button bordered style={this.styles.style.connectWithSliderButton} onPress={() => { this.openConversation(item.id, item.given_name + " " + item.family_name) }}><Text style={this.styles.style.fontStartConversation}>Start Conversation</Text></Button>
-                          </Body>
-                        </Left>
-                      </CardItem>
-                    </Card>
-                  </TouchableOpacity>
-                )
+                            <Body>
+                              <Text style={styles.fontConnectWithName}>{item.given_name} {item.family_name}</Text>
+                              <Text style={styles.fontConnectWithRole}>{item.currentRole}</Text>
+                              <Button bordered style={styles.connectWithSliderButton} onPress={() => { this.openConversation(item.id, item.given_name + " " + item.family_name) }}><Text style={styles.fontStartConversation}>Start Conversation</Text></Button>
+                            </Body>
+                          </Left>
+                        </CardItem>
+                      </Card>
+                    </TouchableOpacity>
+                  )
+                } else {
+                  return null
+                }
               })}
             </Content>
 

--- a/components/MyPeople/MyPeople.tsx
+++ b/components/MyPeople/MyPeople.tsx
@@ -112,16 +112,16 @@ export default class MyPeople extends JCComponent<Props, State> {
                 if (item.id !== this.state.currentUser) {
                   return (
                     <TouchableOpacity key={item.id} onPress={() => { this.showProfile(item.id) }}>
-                      <Card style={styles.dashboardConversationCard}>
+                      <Card style={this.styles.dashboardConversationCard}>
                         <CardItem>
                           <Left>
                             <ProfileImage user={item} size='small'>
                             </ProfileImage>
 
                             <Body>
-                              <Text style={styles.fontConnectWithName}>{item.given_name} {item.family_name}</Text>
-                              <Text style={styles.fontConnectWithRole}>{item.currentRole}</Text>
-                              <Button bordered style={styles.connectWithSliderButton} onPress={() => { this.openConversation(item.id, item.given_name + " " + item.family_name) }}><Text style={styles.fontStartConversation}>Start Conversation</Text></Button>
+                              <Text style={this.styles.fontConnectWithName}>{item.given_name} {item.family_name}</Text>
+                              <Text style={this.styles.fontConnectWithRole}>{item.currentRole}</Text>
+                              <Button bordered style={this.styles.connectWithSliderButton} onPress={() => { this.openConversation(item.id, item.given_name + " " + item.family_name) }}><Text style={this.styles.fontStartConversation}>Start Conversation</Text></Button>
                             </Body>
                           </Left>
                         </CardItem>

--- a/components/MyPeople/MyPeople.tsx
+++ b/components/MyPeople/MyPeople.tsx
@@ -112,28 +112,16 @@ export default class MyPeople extends JCComponent<Props, State> {
                 if (item.id !== this.state.currentUser) {
                   return (
                     <TouchableOpacity key={item.id} onPress={() => { this.showProfile(item.id) }}>
-<<<<<<< HEAD
                       <Card style={this.styles.dashboardConversationCard}>
-=======
-                      <Card style={styles.dashboardConversationCard}>
->>>>>>> 5a3b6c3a1464ca2cbba7d5dbd2c10e9a942bc14b
                         <CardItem>
                           <Left>
                             <ProfileImage user={item} size='small'>
                             </ProfileImage>
-<<<<<<< HEAD
 
                             <Body>
                               <Text style={this.styles.fontConnectWithName}>{item.given_name} {item.family_name}</Text>
                               <Text style={this.styles.fontConnectWithRole}>{item.currentRole}</Text>
                               <Button bordered style={this.styles.connectWithSliderButton} onPress={() => { this.openConversation(item.id, item.given_name + " " + item.family_name) }}><Text style={this.styles.fontStartConversation}>Start Conversation</Text></Button>
-=======
-  
-                            <Body>
-                              <Text style={styles.fontConnectWithName}>{item.given_name} {item.family_name}</Text>
-                              <Text style={styles.fontConnectWithRole}>{item.currentRole}</Text>
-                              <Button bordered style={styles.connectWithSliderButton} onPress={() => { this.openConversation(item.id, item.given_name + " " + item.family_name) }}><Text style={styles.fontStartConversation}>Start Conversation</Text></Button>
->>>>>>> 5a3b6c3a1464ca2cbba7d5dbd2c10e9a942bc14b
                             </Body>
                           </Left>
                         </CardItem>

--- a/components/MyProfile/MapSelector.web.tsx
+++ b/components/MyProfile/MapSelector.web.tsx
@@ -8,8 +8,8 @@ import JCButton, { ButtonTypes } from '../../components/Forms/JCButton'
 import { Marker } from 'google-maps-react';
 import { Map } from 'google-maps-react';
 import JCComponent from '../JCComponent/JCComponent';
-
-
+import styles from '../../components/style'
+import mapStyle from './mapstyle.json';
 
 interface Props {
     mapVisible: any,
@@ -31,6 +31,12 @@ class MapSelector extends JCComponent<Props, State> {
         }
     }
 
+    _mapLoaded(map) {
+        map.setOptions({
+            styles: mapStyle
+        })
+    }
+
     render() {
         return (
 
@@ -41,11 +47,14 @@ class MapSelector extends JCComponent<Props, State> {
                             <Text style={this.styles.style.mapSelectorText}>Select a location (this will be public)</Text>
                             <JCButton data-testid="mapselector-save" buttonType={ButtonTypes.SolidMap} onPress={() => this.props.onClose(this.state.mapCoord)}>Done</JCButton>
                         </View>
-                        <Container style={this.styles.style.mapView}>
-                            <Map google={window.google} zoom={6}
-                                initialCenter={{ lat: 44, lng: -78.0 }}
+                        <Container style={styles.mapView}>
+                            <Map google={window.google} zoom={2}
+                                initialCenter={{ lat: 0, lng: 0 }}
                                 mapTypeControl={false}
-                                style={this.styles.style.map}
+                                onReady={(mapProps, map) => this._mapLoaded(map)}
+                                style={styles.map}
+                                streetViewControl={false}
+                                fullscreenControl={false}
                             >
                                 <Marker
                                     title="Location"
@@ -56,6 +65,10 @@ class MapSelector extends JCComponent<Props, State> {
                                         console.log(e)
                                         console.log(coord.latLng)
                                         this.setState({ mapCoord: { latitude: coord.latLng.lat(), longitude: coord.latLng.lng() } })
+                                    }}
+                                    icon={{
+                                        url: require("../../assets/svg/map-icon-red.svg"),
+                                        scaledSize: new google.maps.Size(32, 32)
                                     }}
                                 ></Marker>
 

--- a/components/MyProfile/MyProfile.tsx
+++ b/components/MyProfile/MyProfile.tsx
@@ -65,7 +65,7 @@ class MyProfileImpl extends JCComponent<Props, State> {
       this.setState({
         mapData: [{
           latitude: this.state.UserDetails.location.latitude,
-          longitude: this.state.UserDetails.location.latitude,
+          longitude: this.state.UserDetails.location.longitude,
           name: this.state.UserDetails.given_name + " " + this.state.UserDetails.family_name,
           user: this.state.UserDetails,
           link: "",
@@ -401,7 +401,7 @@ class MyProfileImpl extends JCComponent<Props, State> {
 
             <View style={this.styles.style.profileScreenRightCard}>
               <View style={{ width: '100%' }}>
-                <MyMap initCenter={this.state.initCenter} visible={true} mapData={this.state.mapData} showFilters={false}></MyMap>
+                <MyMap initCenter={this.state.initCenter} visible={true} mapData={this.state.mapData} type={"profile"}></MyMap>
               </View>
               {this.state.isEditable ?
                 <Text style={this.styles.style.fontMyProfileLeftTop}>Tell us more about you</Text>

--- a/components/MyProfile/mapstyle.json
+++ b/components/MyProfile/mapstyle.json
@@ -1,0 +1,160 @@
+[
+  {
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#f5f5f5"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.icon",
+    "stylers": [
+      {
+        "visibility": "off"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#616161"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.text.stroke",
+    "stylers": [
+      {
+        "color": "#f5f5f5"
+      }
+    ]
+  },
+  {
+    "featureType": "administrative.land_parcel",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#bdbdbd"
+      }
+    ]
+  },
+  {
+    "featureType": "poi",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#eeeeee"
+      }
+    ]
+  },
+  {
+    "featureType": "poi",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#757575"
+      }
+    ]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#e5e5e5"
+      }
+    ]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#9e9e9e"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#ffffff"
+      }
+    ]
+  },
+  {
+    "featureType": "road.arterial",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#757575"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#dadada"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#616161"
+      }
+    ]
+  },
+  {
+    "featureType": "road.local",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#9e9e9e"
+      }
+    ]
+  },
+  {
+    "featureType": "transit.line",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#e5e5e5"
+      }
+    ]
+  },
+  {
+    "featureType": "transit.station",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#eeeeee"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#c9c9c9"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#9e9e9e"
+      }
+    ]
+  }
+]

--- a/screens/ConversationScreen/ConversationScreen.tsx
+++ b/screens/ConversationScreen/ConversationScreen.tsx
@@ -114,11 +114,11 @@ export default class ConversationScreen extends JCComponent<Props, State>{
 
       <Container >
         <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
-        <MyMap visible={this.state.showMap}></MyMap>
         <Content>
-          <Container style={this.styles.style.conversationScreenMainContainer}>
-            <Container style={this.styles.style.detailScreenLeftCard}>
-              <Text style={this.styles.style.eventNameInput}>Direct Messages</Text>
+          <MyMap type={'no-filters'} visible={this.state.showMap} mapData={[]}></MyMap>
+          <Container style={styles.conversationScreenMainContainer}>
+            <Container style={styles.detailScreenLeftCard}>
+              <Text style={styles.eventNameInput}>Direct Messages</Text>
 
               {this.state.data != null ?
                 this.state.data.items.map((item, index) => {

--- a/screens/CoursesScreen/CoursesScreen.tsx
+++ b/screens/CoursesScreen/CoursesScreen.tsx
@@ -38,8 +38,8 @@ export default class HomeScreen extends JCComponent<Props, State>{
 
       <Container >
         <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
-        <MyMap mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
         <Content>
+          <MyMap type={'no-filters'} size={'50%'} mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
           <Container style={{ display: "flex", flexDirection: "row", justifyContent: 'flex-start' }}>
             <Container style={{ flex: 70, flexDirection: "column", justifyContent: 'flex-start' }}>
               <MyGroups showMore={true} type="course" wrap={true} navigation={this.props.navigation} onDataload={(mapData) => { this.mergeMapData(mapData) }}></MyGroups>

--- a/screens/EventScreen/EventScreen.tsx
+++ b/screens/EventScreen/EventScreen.tsx
@@ -354,9 +354,10 @@ export default class EventScreen extends JCComponent<Props, State>{
       this.state.data ?
         <StyleProvider style={getTheme(material)}>
           <Container>
-            <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
+            <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={!this.state.createNew && this.state.data.eventType === "location" ? this.mapChanged : null} />
             <Content>
-              <MyMap initCenter={this.state.initCenter} type={"no-filters"} size={'25%'} visible={this.state.showMap} mapData={this.state.mapData}></MyMap>              <Container style={this.styles.style.eventScreenMainContainer}>
+              <MyMap initCenter={this.state.initCenter} type={"no-filters"} size={'25%'} visible={this.state.showMap} mapData={this.state.mapData}></MyMap>
+              <Container style={this.styles.style.eventScreenMainContainer}>
                 <Container style={this.styles.style.detailScreenLeftCard}>
                   <Container style={{ flexDirection: "row", width: "100%", justifyContent: "space-between", flexGrow: 0, marginBottom: 20 }}>
                     <Text style={{ fontSize: 12, lineHeight: 16, fontFamily: "Graphik-Regular-App", color: '#333333', textTransform: "uppercase", flex: 0 }}>Event</Text>

--- a/screens/EventScreen/EventScreen.tsx
+++ b/screens/EventScreen/EventScreen.tsx
@@ -42,6 +42,8 @@ interface State {
   currentUser: string
   currentUserProfile: any
   attendeeIDs: string[]
+  mapData: any
+  initCenter: any
 }
 
 
@@ -63,7 +65,9 @@ export default class EventScreen extends JCComponent<Props, State>{
       validationError: "",
       currentUser: null,
       currentUserProfile: null,
-      attendeeIDs: []
+      attendeeIDs: [],
+      mapData: [],
+      initCenter: { lat: 44, lng: -78 }
     }
     Auth.currentAuthenticatedUser().then((user: any) => {
       this.setState({
@@ -142,6 +146,8 @@ export default class EventScreen extends JCComponent<Props, State>{
         },
 
           () => {
+            this.convertEventToMapData();
+
             const groupMemberByUser: any = API.graphql({
               query: queries.groupMemberByUser,
               variables: { userID: this.state.currentUser, groupID: { eq: this.state.data.id } },
@@ -160,6 +166,22 @@ export default class EventScreen extends JCComponent<Props, State>{
       getGroup.then(processResults).catch(processResults)
     }
   }
+  convertEventToMapData() {
+    const data = this.state.data
+    if (data.locationLatLong && data.locationLatLong.latitude && data.locationLatLong.longitude)
+      this.setState({
+        mapData: [{
+          latitude: data.locationLatLong.latitude,
+          longitude: data.locationLatLong.longitude,
+          name: data.name,
+          event: data,
+          link: "",
+          type: "event"
+        }],
+        initCenter: { lat: data.locationLatLong.latitude, lng: data.locationLatLong.longitude }
+      })
+  }
+
   mapChanged = (): void => {
     this.setState({ showMap: !this.state.showMap })
   }
@@ -333,9 +355,8 @@ export default class EventScreen extends JCComponent<Props, State>{
         <StyleProvider style={getTheme(material)}>
           <Container>
             <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
-            <MyMap visible={this.state.showMap}></MyMap>
             <Content>
-              <Container style={this.styles.style.eventScreenMainContainer}>
+              <MyMap initCenter={this.state.initCenter} type={"no-filters"} size={'25%'} visible={this.state.showMap} mapData={this.state.mapData}></MyMap>              <Container style={this.styles.style.eventScreenMainContainer}>
                 <Container style={this.styles.style.detailScreenLeftCard}>
                   <Container style={{ flexDirection: "row", width: "100%", justifyContent: "space-between", flexGrow: 0, marginBottom: 20 }}>
                     <Text style={{ fontSize: 12, lineHeight: 16, fontFamily: "Graphik-Regular-App", color: '#333333', textTransform: "uppercase", flex: 0 }}>Event</Text>

--- a/screens/EventsScreen/EventsScreen.tsx
+++ b/screens/EventsScreen/EventsScreen.tsx
@@ -40,8 +40,8 @@ export default class HomeScreen extends JCComponent<Props, State>{
 
       <Container data-testid="events">
         <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
-        <MyMap mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
         <Content>
+          <MyMap type={"no-filters"} size={'50%'} mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
           <Container style={this.styles.style.eventsScreenMainContainer}>
             <Container style={this.styles.style.eventsScreenLeftContainer}>
               <MyGroups showMy={this.state.showMy} showMore={true} type="event" wrap={true} navigation={this.props.navigation} onDataload={(mapData) => { this.mergeMapData(mapData) }}></MyGroups>

--- a/screens/EventsScreen/EventsScreen.tsx
+++ b/screens/EventsScreen/EventsScreen.tsx
@@ -41,15 +41,9 @@ export default class HomeScreen extends JCComponent<Props, State>{
       <Container data-testid="events">
         <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
         <Content>
-<<<<<<< HEAD
           <MyMap type={"no-filters"} size={'50%'} mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
           <Container style={this.styles.style.eventsScreenMainContainer}>
             <Container style={this.styles.style.eventsScreenLeftContainer}>
-=======
-          <MyMap type={"no-filters"} size={'50%'} navigation={this.props.navigation} mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
-          <Container style={style.eventsScreenMainContainer}>
-            <Container style={style.eventsScreenLeftContainer}>
->>>>>>> 5a3b6c3a1464ca2cbba7d5dbd2c10e9a942bc14b
               <MyGroups showMy={this.state.showMy} showMore={true} type="event" wrap={true} navigation={this.props.navigation} onDataload={(mapData) => { this.mergeMapData(mapData) }}></MyGroups>
 
             </Container>

--- a/screens/GroupScreen/GroupScreen.tsx
+++ b/screens/GroupScreen/GroupScreen.tsx
@@ -377,7 +377,7 @@ export default class GroupScreen extends JCComponent<Props, State>{
       this.state.data ?
         <StyleProvider style={getTheme(material)}>
           <Container >
-            <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
+            <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.state.createNew ? null : this.mapChanged} />
             <Content>
               <MyMap type={"no-filters"} size={'25%'} visible={this.state.showMap} mapData={this.state.mapData}></MyMap>
               <Container style={this.styles.style.groupScreenMainContainer}>

--- a/screens/GroupScreen/GroupScreen.tsx
+++ b/screens/GroupScreen/GroupScreen.tsx
@@ -39,7 +39,9 @@ interface State {
   validationError: string
   currentUser: string
   currentUserProfile: any
-  memberIDs: string[]
+  memberIDs: string[],
+  members: any
+  mapData: any
 }
 
 
@@ -61,7 +63,9 @@ export default class GroupScreen extends JCComponent<Props, State>{
       validationError: "",
       currentUser: null,
       currentUserProfile: null,
-      memberIDs: []
+      memberIDs: [],
+      members: [],
+      mapData: []
     }
     Auth.currentAuthenticatedUser().then((user: any) => {
       this.setState({
@@ -145,12 +149,59 @@ export default class GroupScreen extends JCComponent<Props, State>{
                 this.setState({ canJoin: false, canLeave: true && !this.state.isEditable })
               else
                 this.setState({ canJoin: true && !this.state.isEditable, canLeave: false })
-            })
+            });
+
+            this.state.memberIDs.map(id => {
+              const getUser: any = API.graphql({
+                query: queries.getUser,
+                variables: { id: id },
+                authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS
+              });
+              getUser.then((json: any) => {
+                this.setState({ members: this.state.members.concat(json.data.getUser) }, () => {
+                  this.setState({ mapData: this.state.mapData.concat(this.convertProfileToMapData(this.state.members)) })
+                })
+              }).catch((e: any) => {
+                if (e.data) {
+                  this.setState({ members: this.state.members.concat(e.data.getUser) }, () => {
+                    this.setState({ mapData: this.state.mapData.concat(this.convertProfileToMapData(this.state.members)) })
+                  })
+                }
+              })
+            });
+
+            const getUser: any = API.graphql({
+              query: queries.getUser,
+              variables: { id: this.state.data.owner },
+              authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS
+            });
+            getUser.then((json: any) => {
+              this.setState({ mapData: this.state.mapData.concat(this.convertProfileToMapData([json.data.getUser])) })
+            }).catch((e: any) => {
+              if (e.data) {
+                this.setState({ mapData: this.state.mapData.concat(this.convertProfileToMapData([e.data.getUser])) })
+              }
+            });
           }
         )
       }
       getGroup.then(processResults).catch(processResults)
     }
+  }
+  convertProfileToMapData(data): [] {
+    return data.map((dataItem) => {
+      if (dataItem.location && dataItem.location.latitude && dataItem.location.longitude) {
+        return {
+          latitude: dataItem.location.latitude,
+          longitude: dataItem.location.longitude,
+          name: dataItem.given_name + " " + dataItem.family_name,
+          user: dataItem,
+          link: "",
+          type: "profile"
+        }
+      }
+      else return null
+    }).filter(o => o)
   }
   mapChanged = (): void => {
     this.setState({ showMap: !this.state.showMap })
@@ -327,8 +378,8 @@ export default class GroupScreen extends JCComponent<Props, State>{
         <StyleProvider style={getTheme(material)}>
           <Container >
             <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
-            <MyMap visible={this.state.showMap}></MyMap>
             <Content>
+              <MyMap type={"no-filters"} size={'25%'} visible={this.state.showMap} mapData={this.state.mapData}></MyMap>
               <Container style={this.styles.style.groupScreenMainContainer}>
                 <Container style={this.styles.style.detailScreenLeftCard}>
                   <Container style={{ display: "flex", flexDirection: "row", width: "100%", justifyContent: "space-between", flexGrow: 0, marginBottom: 20 }}>

--- a/screens/GroupsScreen/GroupsScreen.tsx
+++ b/screens/GroupsScreen/GroupsScreen.tsx
@@ -37,9 +37,10 @@ export default class HomeScreen extends JCComponent<Props, State>{
     console.log("Homepage")
     return (
       <Container data-testid="groups" >
-        <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
-        <MyMap mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
+        <Header title="Jesus Collective" navigation={this.props.navigation} />
         <Content>
+          {/*Map not displayed since Groups currently don't have location data need to re-add onMapChange to <Header/>
+          <MyMap size={'50%'} type={"no-filters"}  mapData={this.state.mapData} visible={this.state.showMap}></MyMap>*/}
           <Container style={this.styles.style.groupsScreenMainContainer}>
             <Container style={this.styles.style.groupsScreenLeftContainer}>
               <MyGroups showMy={this.state.showMy} showMore={true} type="group" wrap={true} navigation={this.props.navigation} onDataload={(mapData) => { this.mergeMapData(mapData) }}></MyGroups>

--- a/screens/HomeScreen/HomeScreen.tsx
+++ b/screens/HomeScreen/HomeScreen.tsx
@@ -54,9 +54,9 @@ class HomeScreen extends JCComponent<Props, State>{
     return (
       <Container data-testid="homepage">
         <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
-        <MyMap showFilters={true} mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
 
         <Container style={{ flexGrow: 1, overflow: "scroll" }}>
+          <MyMap type={'filters'} mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
           <Container style={this.styles.style.dashboardPrimaryContainer}>
             <Container style={this.styles.style.dashboardMainContainer}>
               <Container style={this.styles.style.dashboardLeftCard}>

--- a/screens/OrganizationScreen/OrganizationScreen.tsx
+++ b/screens/OrganizationScreen/OrganizationScreen.tsx
@@ -209,8 +209,8 @@ export default class GroupScreen extends JCComponent<Props, State>{
         <StyleProvider style={getTheme(material)}>
           <Container >
             <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
-            <MyMap visible={this.state.showMap}></MyMap>
             <Content>
+              <MyMap type={'no-filters'} size={'25%'} visible={this.state.showMap} mapData={[]}></MyMap>
               <Container style={{ display: "flex", flexDirection: "row", justifyContent: 'flex-start' }}>
                 <Container style={{ flex: 30, flexDirection: "column", justifyContent: 'flex-start' }}>
                   <Text>Organization</Text>

--- a/screens/OrganizationsScreen/OrganizationsScreen.tsx
+++ b/screens/OrganizationsScreen/OrganizationsScreen.tsx
@@ -38,8 +38,9 @@ export default class HomeScreen extends JCComponent<Props, State>{
 
       <Container data-testid="organizations">
         <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
-        <MyMap mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
         <Content>
+          <MyMap type={'no-filter'} size={'50%'} mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
+
           <Container style={{ display: "flex", flexDirection: "row", justifyContent: 'flex-start' }}>
             <Container style={{ flex: 70, flexDirection: "column", justifyContent: 'flex-start' }}>
               <MyGroups showMore={true} type="organization" wrap={true} navigation={this.props.navigation} onDataload={(mapData) => { this.mergeMapData(mapData) }}></MyGroups>

--- a/screens/ProfilesScreen/ProfilesScreen.tsx
+++ b/screens/ProfilesScreen/ProfilesScreen.tsx
@@ -37,8 +37,8 @@ export default class HomeScreen extends JCComponent<Props, State>{
 
       <Container data-testid="profiles">
         <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
-        <MyMap mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
         <Content>
+          <MyMap type={"no-filters"} mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
           <Container style={this.styles.style.profilesScreenMainContainer}>
             <Container style={this.styles.style.profilesScreenLeftContainer}>
               <MyGroups showMore={true} type="profile" wrap={true} navigation={this.props.navigation} onDataload={(mapData) => { this.mergeMapData(mapData) }}></MyGroups>

--- a/screens/ResourceScreen/ResourceScreen.tsx
+++ b/screens/ResourceScreen/ResourceScreen.tsx
@@ -40,7 +40,7 @@ class ResourceScreenImpl extends JCComponent<Props, State>{
       <StyleProvider style={getTheme(material)}>
         <Container >
           <Header title="Jesus Collective" navigation={this.props.navigation} />
-          <MyMap visible={this.state.showMap}></MyMap>
+          <MyMap type={'no-filters'} mapData={[]} visible={this.state.showMap}></MyMap>
           <ResourceViewer navigation={this.props.navigation} groupId={this.props.route.params.id}></ResourceViewer>
           <ImportKidsAndYouth></ImportKidsAndYouth>
         </Container>

--- a/screens/ResourcesScreen/ResourcesScreen.tsx
+++ b/screens/ResourcesScreen/ResourcesScreen.tsx
@@ -38,8 +38,8 @@ export default class HomeScreen extends JCComponent<Props, State>{
 
       <Container data-testid="resources" >
         <Header title="Jesus Collective" navigation={this.props.navigation} />
-        <MyMap mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
         <Content>
+          <MyMap type={"no-filters"} size={'50%'} mapData={this.state.mapData} visible={this.state.showMap}></MyMap>
           <Container style={this.styles.style.resourcesScreenMainContainer}>
             <Container style={this.styles.style.resourcesScreenLeftContainer}>
 

--- a/screens/SearchScreen/SearchScreen.tsx
+++ b/screens/SearchScreen/SearchScreen.tsx
@@ -54,8 +54,8 @@ export default class GroupScreen extends JCComponent<Props, State>{
     return <StyleProvider style={getTheme(material)}>
       <Container >
         <Header title="Jesus Collective" navigation={this.props.navigation} onMapChange={this.mapChanged} />
-        <MyMap visible={this.state.showMap}></MyMap>
         <Content>
+          <MyMap type={"no-filters"} visible={this.state.showMap} mapData={[]}></MyMap>
           <Container>
             <input onChange={(item: any) => { this.search(item) }} placeholder="Search..."></input>
             <Text>Results:</Text>


### PR DESCRIPTION
Resolves #146 

Edit: Lots of stuff in this PR after https://github.com/jesus-collective/mobile/pull/148/commits/c9c569bb5dc4d2c6d42f6a0fd031423d86eb3059

- Moves map inside scrolling container pretty much everywhere
- Adds mandatory prop `type` to all `<MyMap/>` components and optional `size` prop to most
- Adds prop `mapData` where missing (set as [] for now) 
- Displays all users on ProfilesScreen
- Displays all events on EventsScreen
- Displays event on EventScreen and set map centre to event location
- Hides map on GroupsScreen (#155)
- Displays group members and group owner on GroupScreen
- Adjusts MapSelector to zoom out and set map centre to `{lat: 0, lng: 0}` since this is where the draggable pin starts - hopefully people will realize they are in the middle of the ocean and actually move the pin
- Adds custom theme, custom marker to MapSelector
- Removes Street View and full screen from MapSelector 
- Keeps current user on map, but retains changes in #140