### PR TITLE
Schema edits to store geocode data

### DIFF
--- a/amplify/backend/api/jcmobile/schema.graphql
+++ b/amplify/backend/api/jcmobile/schema.graphql
@@ -45,6 +45,9 @@ type User
 type LatLong {
   latitude: String
   longitude: String
+  geocodeFull: String
+  geocodeCity: String
+  geocodeRegion: String
 }
 type Image {
   userId: String


### PR DESCRIPTION
Relates to #154.

`geocodeFull`: store full API response string
`geocodeCity`: store just the city
`geocodeRegion`: store just the state/province