### PR TITLE
DMs: prevent multiple rooms from creating, other fixes

### DIFF
--- a/components/MessageBoard/MessageBoard.tsx
+++ b/components/MessageBoard/MessageBoard.tsx
@@ -137,7 +137,7 @@ class MessageBoardImpl extends JCComponent<Props, State> {
         authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS
       });
       const processMessages = (json) => {
-        console.log({ json })
+        console.log(json)
         this.setState({
           created: true,
           data: json.data.directMessagesByRoom,
@@ -158,20 +158,6 @@ class MessageBoardImpl extends JCComponent<Props, State> {
     }
   }
 
-
-  async getDM(id: string) {
-    try {
-      const json: any = await API.graphql({
-        query: queries.getDirectMessageRoom,
-        variables: { id: id },
-        authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS
-      });
-      console.log(json.data.getDirectMessageRoom)
-    } catch (e) {
-      console.error(e)
-    }
-  }
-
   saveMessage() {
     const message = JSON.stringify(convertToRaw(this.state.editorState.getCurrentContent()))
     Auth.currentAuthenticatedUser().then((user: any) => {
@@ -183,7 +169,7 @@ class MessageBoardImpl extends JCComponent<Props, State> {
           roomId: this.props.groupId,
           userId: user.username,
           owner: user.username,
-          authorOrgId: "0"
+          //authorOrgId: "0"
         }
         const createMessage: any = API.graphql({
           query: mutations.createMessage,
@@ -320,13 +306,15 @@ class MessageBoardImpl extends JCComponent<Props, State> {
             })}
 
             {this.props.roomId && this.state.data.items.map((item: any) => {
-              this.getDM(item.messageRoomID)
+              if (!item?.author) {
+                return null
+              }
               return (
                 <TouchableOpacity key={item.id} onPress={() => { this.showProfile(item.author.id) }}>
                   <Card key={item.id} style={{ borderRadius: 10, minHeight: 50, marginBottom: 35, borderColor: "#ffffff" }}>
                     <CardItem style={this.styles.style.eventPageMessageBoard}>
                       <Left style={this.styles.style.eventPageMessageBoardLeft}>
-                        <ProfileImage size="small" user={item.owner ? item.owner : null}></ProfileImage>
+                        <ProfileImage size="small" user={item.author?.id ?? null}></ProfileImage>
                         <Body>
                           <Text style={this.styles.style.groupFormName}>
                             {item.author != null ? item.author.given_name : null} {item.author != null ? item.author.family_name : null}

--- a/components/MyProfile/MyProfile.tsx
+++ b/components/MyProfile/MyProfile.tsx
@@ -148,6 +148,7 @@ class MyProfileImpl extends JCComponent<Props, State> {
     delete item.createdAt
     delete item.updatedAt
     delete item.profileImage["__typename"]
+    delete item.directMessages
     return item
   }
   async finalizeProfile(): Promise<void> {
@@ -372,7 +373,7 @@ class MyProfileImpl extends JCComponent<Props, State> {
                 }
                 <EditableText onChange={(e) => { this.handleInputChange(e, "aboutMeShort") }}
                   placeholder="Short sentence about me" multiline={true}
-                  placeholderTextColor = "#757575"
+                  placeholderTextColor="#757575"
                   textStyle={this.styles.style.fontFormSmallDarkGrey}
                   inputStyle={this.styles.style.fontFormAboutMe}
                   data-testid="profile-aboutMeShort"
@@ -387,7 +388,7 @@ class MyProfileImpl extends JCComponent<Props, State> {
                   <Button bordered style={this.styles.style.connectWithSliderButton} onPress={() => { this.openConversation(this.state.UserDetails.id, this.state.UserDetails.given_name + " " + this.state.UserDetails.family_name) }}><Text style={this.styles.style.fontStartConversation}>Start Conversation</Text></Button>
                   : null}
 
-                {this.state.isEditable && constants['SETTING_ISVISIBLE_PROFILE_MESSAGES'] ?
+                {this.state.isEditable && this.state.UserDetails.profileState !== "Incomplete" && constants['SETTING_ISVISIBLE_PROFILE_MESSAGES'] ?
                   <Text><JCButton data-testid="profile-setmap" buttonType={ButtonTypes.TransparentNoPadding} onPress={() => { this.props.navigation.push("ConversationScreen", { initialUserID: null, initialUserName: null }) }}>Messages</JCButton></Text>
                   : null
                 }


### PR DESCRIPTION
- Error checking for DMs without an author
- Get profile images to load on DMs
- Fix profile to hide messages button during creation and clean input of DMs
- Prevent multiple rooms from creating between two users (add nextToken to getInitialData function)

Edit: closes #237.