### PR TITLE
userName field in DM user table

### DIFF
--- a/amplify/backend/api/jcmobile/schema.graphql
+++ b/amplify/backend/api/jcmobile/schema.graphql
@@ -254,6 +254,7 @@ type DirectMessageUser
  @key(name: "byUser", fields: ["roomID", "userID"])
 {
   id:ID!
+  userName:String  
   userID:ID!
   user:User @connection(fields:["userID"])
   roomID:ID!


### PR DESCRIPTION
I think this schema change is the best way to handle #257.

The `name` field in `DirectMessageRoom` will only used for group chats (and will display if a user sets it). Otherwise, this new `userName` field will be used and display the names of all other users (with some sort of text render limit).