### PR TITLE
Schema changes for profile (org details)

### DIFF
--- a/amplify/backend/api/jcmobile/schema.graphql
+++ b/amplify/backend/api/jcmobile/schema.graphql
@@ -36,6 +36,10 @@ type User
   orgName: String
   orgType: String
   orgSize: String
+  denomination: String
+  pplServed: String
+  sundayAttendance: String
+  numberVolunteers: String
   orgDescription: String
   joined: String
  


### PR DESCRIPTION
There's a bunch of extra fields for organization description aside from "How many employees do you have?" that I was unware of:

- Average Sunday morning attendance
- Number of Volunteers
- Denomination
- How many people do you serve?