### PR TITLE
Add auth rules to DMs in schema

### DIFF
--- a/amplify/backend/api/jcmobile/schema.graphql
+++ b/amplify/backend/api/jcmobile/schema.graphql
@@ -312,9 +312,22 @@ type DirectMessage
 {
   id: ID!
   content: String!
-  attachment: String
+    @auth(rules: [
+      { allow: owner, ownerField: "userId", operations: [create, update, read] },
+      { allow: owner, ownerField: "recipients", operations: [create, update, read] },
+    ])
+  attachment: String 
+    @auth(rules: [
+      { allow: owner, ownerField: "userId", operations: [create, update, read] },
+      { allow: owner, ownerField: "recipients", operations: [create, update, read] },
+    ])
   attachmentName: String
+    @auth(rules: [
+      { allow: owner, ownerField: "userId", operations: [create, update, read] },
+      { allow: owner, ownerField: "recipients", operations: [create, update, read] },
+    ])
   when: String!
+  recipients: [String]!
   userId: ID!
   author: User @connection(fields: ["userId"])
   messageRoomID:ID!


### PR DESCRIPTION
Per https://github.com/jesus-collective/mobile/issues/242#issuecomment-656921281

We can try this out in the dev environment first. I think this will cause breaking changes to beta since all previous messages would be missing the `recipients: [String]!` field.