### PR TITLE
Organization updates (create events, groups, adding admins)

### DIFF
--- a/amplify/backend/api/jcmobile/schema.graphql
+++ b/amplify/backend/api/jcmobile/schema.graphql
@@ -161,6 +161,7 @@ type OrganizationMember
   userRole: String!
   userId: ID!
   organizationId: ID!
+  organizationName: String
   user: User! @connection(fields: ["userId"])
   organization: Organization! @connection(fields: ["organizationId"])
 }


### PR DESCRIPTION
Users can now create events and groups on behalf of an organization of which they are admin or superAdmin. Edits schema to add organizationName to the OrganizationMember table - this is required to display the names if they select an organization during event/group creation.

Future improvements are required as only the admin who created the event/group has edit permissions (this likely needs custom VTL).

Updates the add admins functionality to create a new OrganizationMember with userRole = 'admin' (before it just added them to the admins field).
