### PR TITLE
Events will now show in upcoming until the end of the day

### DIFF
--- a/components/MyGroups/MyGroups.tsx
+++ b/components/MyGroups/MyGroups.tsx
@@ -1150,8 +1150,8 @@ export default class MyGroups extends JCComponent<Props, State> {
   filterEvent = (item: any): boolean => {
     return (
       !(this.props.type === "event") ||
-      (this.state.eventFilter && !moment(item.time).isSameOrAfter(moment.now())) ||
-      (!this.state.eventFilter && moment(item.time).isSameOrAfter(moment.now()))
+      (this.state.eventFilter && !moment(item.time).isSameOrAfter(moment.now(), 'day')) ||
+      (!this.state.eventFilter && moment(item.time).isSameOrAfter(moment.now(), 'day'))
     )
   }
 


### PR DESCRIPTION
- filterEvent now compares days instead of the exact time. Events will now show until the end of their starting day.
resolves #430 