### PR TITLE
Message board: fix TS errors, remove ESLint disable

### DIFF
--- a/.graphqlconfig.yml
+++ b/.graphqlconfig.yml
@@ -10,6 +10,17 @@ projects:
         codeGenTarget: typescript
         generatedFileName: src/API.ts
         docsFilePath: src/graphql
+  messageboard:
+    schemaPath: src/graphql/schema.json
+    includes:
+      - src/graphql-custom/messages.ts
+    excludes:
+      - ./amplify/**
+    extensions:
+      amplify:
+        codeGenTarget: typescript
+        generatedFileName: src/API-messages.ts
+        docsFilePath: src/graphql
 extensions:
   amplify:
     version: 3

--- a/components/MessageBoard/MessageBoard.web.tsx
+++ b/components/MessageBoard/MessageBoard.web.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { GraphQLResult } from "@aws-amplify/api/src/types"
+import { GraphQLResult } from "@aws-amplify/api"
 import { AntDesign, FontAwesome5 } from "@expo/vector-icons"
 import { RouteProp, useNavigation, useRoute } from "@react-navigation/native"
 import { API, Auth, graphqlOperation, Storage } from "aws-amplify"
@@ -151,7 +150,6 @@ class MessageBoardImpl extends JCComponent<Props, State> {
           }
         },
       })
-      // eslint-disable-line
       const replySub = API.graphql({
         query: onCreateReply,
         authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
@@ -205,7 +203,6 @@ class MessageBoardImpl extends JCComponent<Props, State> {
     }
 
     if (this.props.roomId) {
-      // eslint-disable-line
       const dmSub = (await API.graphql({
         query: onCreateDirectMessage,
         authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
@@ -1048,24 +1045,26 @@ class MessageBoardImpl extends JCComponent<Props, State> {
     }
   }
 
-  handlePressReply(item: Message | Reply, isReply: boolean) {
-    const peopleInThread: string[] = []
+  handlePressReply(item: Message | Reply) {
+    if (item) {
+      const peopleInThread: string[] = []
 
-    if (item?.author?.given_name) {
-      peopleInThread.push(item?.author?.given_name)
-    }
-
-    item?.replies?.items?.slice(10).forEach((reply) => {
-      if (reply?.author?.given_name && !peopleInThread.includes(reply?.author?.given_name)) {
-        peopleInThread.push(reply?.author?.given_name)
+      if (item.author?.given_name) {
+        peopleInThread.push(item.author.given_name)
       }
-    })
-    console.log(item?.roomId)
-    this.setState({
-      replyToId: isReply ? item?.messageId : item?.id ?? "",
-      replyToRoomId: isReply ? item?.roomId : item?.roomId,
-      replyToWho: peopleInThread,
-    })
+
+      if ("replies" in item) {
+        item.replies?.items?.slice(10).forEach((reply) => {
+          if (reply?.author?.given_name && !peopleInThread.includes(reply.author.given_name)) {
+            peopleInThread.push(reply?.author?.given_name)
+          }
+        })
+        this.setState({ replyToId: item.id })
+      } else {
+        this.setState({ replyToId: item.messageId })
+      }
+      this.setState({ replyToWho: peopleInThread, replyToRoomId: item.roomId ?? "" })
+    }
   }
 
   renderMessageWithReplies(item: Message, index: number) {
@@ -1075,30 +1074,12 @@ class MessageBoardImpl extends JCComponent<Props, State> {
         {item?.replies?.items?.map((reply, index) => {
           return this.renderMessage(reply, index, true)
         })}
-        {/* {this.props.replies && (
-          <TouchableOpacity
-            style={{ alignSelf: "flex-end", margin: 24, marginTop: 12, borderWidth: 1,borderColor: "#F0493E", borderRadius: 4, paddingTop: 7, paddingBottom: 7, paddingLeft: 23, paddingRight: 23 }}
-            onPress={() => this.handlePressReply(item)}
-          >
-            <Text
-              style={{
-                fontFamily: "Graphik-Regular-App",
-                fontWeight: "regular",
-                fontSize: 14,
-                lineHeight: 20,
-                color: "#F0493E",
-              }}
-            >
-              reply
-            </Text>
-          </TouchableOpacity>
-        )} */}
       </View>
     )
   }
 
   renderMessage(item: Message | Reply, index: number, isReply: boolean) {
-    const { style } = this.props
+    const { style, replies } = this.props
 
     return (
       <Card
@@ -1139,7 +1120,7 @@ class MessageBoardImpl extends JCComponent<Props, State> {
               </Body>
             </Left>
             <Right style={{ justifyContent: "center" }}>
-              {this.props.replies && (
+              {replies && (
                 <TouchableOpacity
                   style={{
                     alignSelf: "flex-end",
@@ -1152,7 +1133,7 @@ class MessageBoardImpl extends JCComponent<Props, State> {
                     paddingLeft: 23,
                     paddingRight: 23,
                   }}
-                  onPress={() => this.handlePressReply(item, isReply)}
+                  onPress={() => this.handlePressReply(item)}
                 >
                   <Text
                     style={{
@@ -1196,7 +1177,7 @@ class MessageBoardImpl extends JCComponent<Props, State> {
                 )}
               </View>
               <View>
-                {this.props.replies && (
+                {replies && (
                   <TouchableOpacity
                     style={{
                       alignSelf: "flex-end",
@@ -1209,7 +1190,7 @@ class MessageBoardImpl extends JCComponent<Props, State> {
                       paddingLeft: 23,
                       paddingRight: 23,
                     }}
-                    onPress={() => this.handlePressReply(item, isReply)}
+                    onPress={() => this.handlePressReply(item)}
                   >
                     <Text
                       style={{

--- a/components/MessageBoard/MessageBoard.web.tsx
+++ b/components/MessageBoard/MessageBoard.web.tsx
@@ -133,12 +133,12 @@ class MessageBoardImpl extends JCComponent<Props, State> {
         query: onCreateMessageByRoomId,
         variables: { roomId: this.props.groupId },
         authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-      }) as Observable<object>
+      }) as Observable<{
+        provider: any
+        value: GraphQLResult<OnCreateMessageByRoomIdSubscription>
+      }>
       this.messageUnsubscribe = messageSub.subscribe({
-        next: (incoming: {
-          provider: any
-          value: GraphQLResult<OnCreateMessageByRoomIdSubscription>
-        }) => {
+        next: (incoming) => {
           console.debug(incoming)
           if (incoming.value.data?.onCreateMessageByRoomId) {
             this.setState({
@@ -153,12 +153,12 @@ class MessageBoardImpl extends JCComponent<Props, State> {
       const replySub = API.graphql({
         query: onCreateReply,
         authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-      }) as Observable<object>
+      }) as Observable<{
+        provider: any
+        value: GraphQLResult<OnCreateReplySubscription>
+      }>
       this.replyUnsubscribe = replySub.subscribe({
-        next: async (incoming: {
-          provider: any
-          value: GraphQLResult<OnCreateReplySubscription>
-        }) => {
+        next: async (incoming) => {
           console.debug(incoming)
           if (
             incoming.value?.data?.onCreateReply?.parentMessage &&
@@ -206,12 +206,12 @@ class MessageBoardImpl extends JCComponent<Props, State> {
       const dmSub = (await API.graphql({
         query: onCreateDirectMessage,
         authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-      })) as Observable<object>
+      })) as Observable<{
+        provider: any
+        value: GraphQLResult<OnCreateDirectMessageSubscription>
+      }>
       this.dmUnsubscribe = dmSub.subscribe({
-        next: async (incoming: {
-          provider: any
-          value: GraphQLResult<OnCreateDirectMessageSubscription>
-        }) => {
+        next: async (incoming) => {
           console.debug(incoming)
           if (
             incoming.value?.data?.onCreateDirectMessage &&
@@ -748,7 +748,10 @@ class MessageBoardImpl extends JCComponent<Props, State> {
                     },
                   }}
                   toolbarCustomButtons={[
-                    <FileUpload handleUploadCallback={(e) => this.handleUpload(e)} />,
+                    <FileUpload
+                      key="fileupload"
+                      handleUploadCallback={(e) => this.handleUpload(e)}
+                    />,
                   ]}
                 />
                 {this.renderWordCount()}

--- a/src/API-messages.ts
+++ b/src/API-messages.ts
@@ -163,6 +163,7 @@ export type GetMessageQuery = {
         updatedAt: string,
         userId: string,
         when: string,
+        roomId: string | null,
       } | null > | null,
     } | null,
   } | null,
@@ -272,6 +273,7 @@ export type MessagesByRoomQuery = {
           updatedAt: string,
           userId: string,
           when: string,
+          roomId: string | null,
         } | null > | null,
       } | null,
     } | null > | null,
@@ -411,6 +413,7 @@ export type OnCreateMessageByRoomIdSubscription = {
         parentReplyId: string,
         createdAt: string,
         updatedAt: string,
+        roomId: string | null,
         author:  {
           __typename: "User",
           id: string,
@@ -493,6 +496,7 @@ export type OnCreateReplySubscription = {
     attachmentName: string | null,
     userId: string,
     messageId: string,
+    roomId: string | null,
     parentMessage:  {
       __typename: "Message",
       roomId: string | null,

--- a/src/graphql-custom/messages.ts
+++ b/src/graphql-custom/messages.ts
@@ -86,6 +86,7 @@ export const getMessage = /* GraphQL */ `
           updatedAt
           userId
           when
+          roomId
         }
       }
     }
@@ -196,6 +197,7 @@ export const messagesByRoom = /* GraphQL */ `
             updatedAt
             userId
             when
+            roomId
           }
         }
       }
@@ -324,6 +326,7 @@ export const onCreateMessageByRoomId = /* GraphQL */ `
           parentReplyId
           createdAt
           updatedAt
+          roomId
           author {
             id
             given_name


### PR DESCRIPTION
I noticed some weirdness in https://github.com/jesus-collective/mobile/commit/05853401fa1756dfe88a7fdaf46604335429b80a and figured I'd help fix.

Type generation for `src/graphql-custom/messages.ts` is now added to the GraphQL config (I assume this is the main source of trouble and the ESLint disables). `roomId` is added to the `replies` field for all queries in `messages.ts`.

Fixes `handlePressReply()` in `MessageBoard.web.tsx`. Removes the `eslint-disable` markers.

Merge risk: this was quick pro bono work. 100% untested.