### PR TITLE
Fix uninitialized variable

### DIFF
--- a/screens/CourseHomeScreen/CourseHomeScreen.web.tsx
+++ b/screens/CourseHomeScreen/CourseHomeScreen.web.tsx
@@ -366,7 +366,7 @@ export default class CourseHomeScreenImpl extends JCComponent<Props, CourseState
       lookupObject[originalArray[i][prop]] = originalArray[i]
     }
 
-    for (i in lookupObject) {
+    for (const i in lookupObject) {
       newArray.push(lookupObject[i])
     }
     return newArray


### PR DESCRIPTION
Course home screen was not loading. Bug introduced in https://github.com/jesus-collective/mobile/commit/8d92153859c4ff4dd27148b26646439b2da5f894.