### PR TITLE
Select manual input fields for CardAuto

### DIFF
--- a/components/ResourceViewer/ResourceCard.tsx
+++ b/components/ResourceViewer/ResourceCard.tsx
@@ -110,6 +110,44 @@ export class ResourceCardImpl extends JCComponent<Props, State> {
                     return <Picker.Item key={org} label={org} value={org} />
                   })}
               </Picker>
+              {page.state.settings.style === ResourcePageItemStyle.CardAuto ? (
+                <>
+                  <Text style={{ textAlign: "left", width: "100%", fontWeight: "800" }}>
+                    Title 1:
+                  </Text>
+                  <EditableText
+                    onChange={(val: string) => {
+                      const tmp = page.state.settings
+                      tmp.title1 = val
+                      page.setState({ settings: tmp })
+                    }}
+                    placeholder="Title 1"
+                    multiline={false}
+                    textStyle={{ textAlign: "left", width: "100%", fontWeight: "400" }}
+                    inputStyle={{ textAlign: "left", width: "100%", fontWeight: "400" }}
+                    value={page.state.settings.title1 ?? ""}
+                    isEditable={true}
+                  />
+                  <Text
+                    style={{ textAlign: "left", width: "100%", fontWeight: "800", marginTop: 15 }}
+                  >
+                    Title 2 (replaces the auto title):
+                  </Text>
+                  <EditableText
+                    onChange={(val: string) => {
+                      const tmp = page.state.settings
+                      tmp.title2 = val
+                      page.setState({ settings: tmp })
+                    }}
+                    placeholder="Title 2"
+                    multiline={false}
+                    textStyle={{ textAlign: "left", width: "100%", fontWeight: "400" }}
+                    inputStyle={{ textAlign: "left", width: "100%", fontWeight: "400" }}
+                    value={page.state.settings.title2 ?? ""}
+                    isEditable={true}
+                  />
+                </>
+              ) : null}
               {page.state.settings.style == ResourcePageItemStyle.CardManual ||
               page.state.settings.style == null ? (
                 <>
@@ -841,7 +879,7 @@ export class ResourceCardImpl extends JCComponent<Props, State> {
                         color: "#F0493E",
                         textTransform: "uppercase",
                       }}
-                      value={""}
+                      value={this.props.pageItem.title1 ?? ""}
                       isEditable={false}
                     ></EditableText>
                   </CardItem>
@@ -872,7 +910,7 @@ export class ResourceCardImpl extends JCComponent<Props, State> {
                         textAlign: "left",
                         color: "#404040",
                       }}
-                      value={item?.title ?? ""}
+                      value={this.props.pageItem.title2 || (item?.title ?? "")}
                       isEditable={false}
                     ></EditableText>
                   </CardItem>


### PR DESCRIPTION
Closes #687.

Admins can optionally input Title 1 and Title 2 for auto cards: 
![image](https://user-images.githubusercontent.com/48423418/108305419-ec092000-7177-11eb-8590-0dac0cc4515c.png)

Note: Title 2 will _replace_ the auto title to prevent UI issues. Title 1 works as expected and can be used in conjugation with the auto title.

I believe only Title 1 is required for what @lucastbelem wants to achieve, but more flexibility doesn't hurt here.