### PR TITLE
Fix lessons sort, add tooltip to button

### DIFF
--- a/components/CourseViewer/CourseContext.tsx
+++ b/components/CourseViewer/CourseContext.tsx
@@ -99,7 +99,7 @@ export interface CourseActions {
   myCourseDates: () => { markedDates: MarkedDates; items: AgendaItems }
   myCourseTodo: () => CourseToDo[]
   setShowChat: () => void
-  sortLessons: () => Promise<void>
+  syncLessonNumbers: () => Promise<void>
   setDateFilter: (date: string) => void
 }
 
@@ -146,7 +146,7 @@ export const CourseContext = React.createContext<CourseContextType>({
       return []
     },
     setShowChat: () => null,
-    sortLessons: () => Promise.resolve(),
+    syncLessonNumbers: () => Promise.resolve(),
     setDateFilter: () => null,
   },
   state: undefined,

--- a/components/CourseViewer/CourseDetail.tsx
+++ b/components/CourseViewer/CourseDetail.tsx
@@ -1,4 +1,5 @@
 ﻿import { AntDesign } from "@expo/vector-icons"
+import { Tooltip } from "@material-ui/core"
 import { useNavigation, useRoute } from "@react-navigation/native"
 import moment from "moment-timezone"
 import { Card, Container, Content, Icon, Picker, StyleProvider } from "native-base"
@@ -445,14 +446,35 @@ class CourseDetailImpl extends JCComponent<Props, JCState> {
         <Container style={this.styles.style.courseDetailLeftContainer}>
           <Container style={this.styles.style.courseDetailCourseInfoContainer}>
             {state.isEditable && state.editMode ? (
-              <JCButton
-                buttonType={ButtonTypes.CourseHomeSidebarTop}
-                onPress={() => {
-                  actions.sortLessons()
+              <Container
+                style={{
+                  display: "flex",
+                  flexDirection: "row",
+                  alignItems: "center",
+                  maxHeight: 85,
                 }}
               >
-                Sort Lessons
-              </JCButton>
+                <JCButton
+                  buttonType={ButtonTypes.CourseHomeSidebarTop}
+                  onPress={() => {
+                    actions.syncLessonNumbers()
+                  }}
+                >
+                  Sync Lesson Numbers
+                </JCButton>
+                <Tooltip
+                  title={`Chronologically synchronize lesson numbers with date/time of lessons. 
+                  It is recommended to use this function after adding/removing lesson(s).`}
+                  placement="right"
+                >
+                  <AntDesign
+                    name="questioncircle"
+                    size={20}
+                    color="black"
+                    style={{ marginLeft: 10 }}
+                  />
+                </Tooltip>
+              </Container>
             ) : null}
             <EditableText
               onChange={(e) => {

--- a/components/CourseViewer/CourseDetail.tsx
+++ b/components/CourseViewer/CourseDetail.tsx
@@ -463,7 +463,7 @@ class CourseDetailImpl extends JCComponent<Props, JCState> {
                   Sync Lesson Numbers
                 </JCButton>
                 <Tooltip
-                  title={`Chronologically synchronize lesson numbers with date/time of lessons. 
+                  title={`Synchronize order of lesson numbers with date/time of lessons. 
                   It is recommended to use this function after adding/removing lesson(s).`}
                   placement="right"
                 >

--- a/screens/CourseHomeScreen/CourseHomeScreen.web.tsx
+++ b/screens/CourseHomeScreen/CourseHomeScreen.web.tsx
@@ -109,11 +109,13 @@ export default class CourseHomeScreenImpl extends JCComponent<Props, CourseState
         if (week?.id) {
           const lessonsObj: CourseWeekObj["lessons"] = {}
 
-          week.lessons?.items?.forEach((lesson) => {
-            if (lesson?.id) {
-              lessonsObj[lesson.id] = lesson
-            }
-          })
+          week.lessons?.items
+            ?.sort((a, b) => (a?.time ?? "")?.localeCompare(b?.time ?? ""))
+            .forEach((lesson) => {
+              if (lesson?.id) {
+                lessonsObj[lesson.id] = lesson
+              }
+            })
 
           const weekObj: CourseWeekObj = { ...week, lessons: lessonsObj }
           courseWeeks[week.id] = weekObj
@@ -190,7 +192,7 @@ export default class CourseHomeScreenImpl extends JCComponent<Props, CourseState
     })
   }
 
-  sortLessons = async (): Promise<void> => {
+  syncLessonNumbers = async (): Promise<void> => {
     const { lessons } = this.state.courseWeeks[this.state.activeWeek]
 
     const sortedLessons = Object.values(lessons).sort((a, b) =>
@@ -1069,7 +1071,7 @@ export default class CourseHomeScreenImpl extends JCComponent<Props, CourseState
             myCourseDates: this.myCourseDates,
             myCourseTodo: this.myCourseTodo,
             setShowChat: () => this.setState({ showChat: !this.state.showChat }),
-            sortLessons: this.sortLessons,
+            syncLessonNumbers: this.syncLessonNumbers,
             setDateFilter: this.setDateFilter,
           },
         }}


### PR DESCRIPTION
Closes #852. Adds a tooltip to the re-named "Sync Lesson Numbers" button to explain its use.