### PR TITLE
Course Week Intro Text and Lessons Overlap Fix

### DIFF
--- a/components/courseStyles.tsx
+++ b/components/courseStyles.tsx
@@ -748,6 +748,7 @@ const courseStyles = EStyleSheet.create({
     : {
         width: "100%",
         minHeight: "fit-content",
+        height: "unset",
       },
   courseHomeCourseActivityText: {
     fontSize: 16,


### PR DESCRIPTION
@JonEsparaz I added a height: unset for any other browser other than Chrome (height: auto). Can you merge this PR to see if this will do the trick? Thx @lucastbelem 