### PR TITLE
Time sort key for events/groups

### DIFF
--- a/amplify/backend/api/jcmobile/schema.graphql
+++ b/amplify/backend/api/jcmobile/schema.graphql
@@ -447,6 +447,7 @@ type Group
 
     ]
   )
+    @key(name: "byTypeByTime", fields: ["type", "time"], queryField: "groupByTypeByTime")
     @key(name: "byType", fields: ["type", "id"], queryField: "groupByType")
   @key(name:"byOwnerOrg", fields:["ownerOrgID","name"])
  {


### PR DESCRIPTION
Allows querying current and past events separately based on the `time` field. Needed for #692.