### PR TITLE
Update Quantities in Billing

### DIFF
--- a/components/Billing/Billing.tsx
+++ b/components/Billing/Billing.tsx
@@ -144,7 +144,7 @@ class BillingImpl extends JCComponent<Props, State> {
               {
                 currentProduct: [listProducts.data.listProducts.items[0]],
                 quantities: [
-                  Array(listProducts.data.listProducts.items[0]?.tiered?.length).fill(1),
+                  Array(listProducts.data.listProducts.items[0]?.tiered?.length).fill(25),
                 ],
               },
               async () => {


### PR DESCRIPTION
Product count should default to 25



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=811672270)
